### PR TITLE
fix handling of multiple quoted sections

### DIFF
--- a/src/packagerix/parsing.py
+++ b/src/packagerix/parsing.py
@@ -190,6 +190,6 @@ def extract_updated_code(model_reply):
         logger.error(error_msg)
         raise ValueError(error_msg)
     elif len(matches) > 1:
-        logger.warning(f"Reply contained {len(matches)} quoted sections, using the first one")
+        logger.warning(f"Reply contained {len(matches)} quoted sections, using the last one")
     
-    return matches[0].group(1)
+    return matches[-1].group(1)


### PR DESCRIPTION
Usually what happens is that models output some auxiliary multiple quoted sections so it seems to make more sense to get the last one instead of the first.